### PR TITLE
Enhance OpenAI prompt for software developer context

### DIFF
--- a/pkg/gitgen/mod.go
+++ b/pkg/gitgen/mod.go
@@ -48,20 +48,24 @@ func getPrompt(promptType PromptType) string {
 }
 
 func Do(promptType PromptType, config Config) (string, error) {
-	prompt := getPrompt(promptType)
+	systemPrompt := getPrompt(promptType)
 
 	// Run the git diff command
-	stdout, _, err := runDiff()
+	userPrompt, _, err := runDiff()
 	if err != nil {
 		return "", err
 	}
 
-	result := fmt.Sprintf("~~~diff\n%s~~~\n\n%s", stdout, prompt)
+	fmt.Println("System Prompt:")
+	fmt.Println(systemPrompt)
+	fmt.Println("User Prompt:")
+	fmt.Println(userPrompt)
 
-	content, err := ExecPrompt(result, config)
+	content, err := ExecPrompt(systemPrompt, userPrompt, config)
 	if err != nil {
 		return "", err
 	}
 
+	fmt.Println("OpenAI Response:")
 	return content.Choices[0].Message.Content, nil
 }

--- a/pkg/gitgen/openapi.go
+++ b/pkg/gitgen/openapi.go
@@ -43,24 +43,24 @@ type PromptResponse struct {
 	} `json:"choices"`
 }
 
-func ExecPrompt(prompt string, config Config) (*PromptResponse, error) {
+func ExecPrompt(systemPrompt string, userPrompt string, config Config) (*PromptResponse, error) {
 	// Create the request body
 	request := PromptRequest{
 		Model: config.PromptModel,
 		Messages: []PromptRequestMessage{
 			{
 				Role:    "system",
-				Content: "Act as a software developer working on a project. You have just run a `git diff` command and see the following changes. According to prompt write a commit message or code review based on these changes. ",
+				Content: systemPrompt,
 			},
 			{
 				Role:    "user",
-				Content: prompt,
+				Content: userPrompt,
 			},
 		},
 		MaxTokens: config.PromptMaxTokens,
 	}
 
-	body, err := json.Marshal(request)
+	body, err := json.MarshalIndent(request, "", "  ") // Use json.MarshalIndent for pretty printing
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Added a new system message to the OpenAI prompt in `ExecPrompt` function to set the context for the AI as a software developer.
- This change improves the response quality for writing commit messages or code reviews based on `git diff` outputs.