### PR TITLE
Add `test` command to generate detailed test cases

### DIFF
--- a/cmd/git-gen/main.go
+++ b/cmd/git-gen/main.go
@@ -145,6 +145,67 @@ func main() {
 				},
 			},
 			{
+				Name:  "test",
+				Usage: "Creating test cases",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:        "apikey",
+						Usage:       "Platform API key",
+						Sources:     cli.EnvVars("PLATFORM_API_KEY"),
+						Destination: &platformApiKey,
+					},
+					&cli.StringFlag{
+						Name:        "source",
+						Usage:       "Source Ref",
+						Value:       "HEAD",
+						Destination: &sourceRef,
+					},
+					&cli.StringFlag{
+						Name:        "dest",
+						Usage:       "Destination Ref",
+						Value:       "",
+						Destination: &destinationRef,
+					},
+					&cli.StringFlag{
+						Name:        "platform",
+						Usage:       "Platform",
+						Value:       "openai",
+						Destination: &platform,
+					},
+					&cli.StringFlag{
+						Name:        "model",
+						Usage:       "Model",
+						Value:       "",
+						Destination: &model,
+					},
+					&cli.IntFlag{
+						Name:        "maxtokens",
+						Usage:       "Maximum tokens to generate",
+						Value:       3500,
+						Destination: &maxTokens,
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					config := gitgen.NewConfig(
+						gitgen.WithPlatformApiKey(platformApiKey),
+						gitgen.WithSourceRef(sourceRef),
+						gitgen.WithDestinationRef(destinationRef),
+						gitgen.WithPlatform(platform),
+						gitgen.WithModel(model),
+						gitgen.WithPromptMaxTokens(maxTokens),
+					)
+
+					result, err := gitgen.Do(gitgen.PromptTestCase, *config)
+
+					if err != nil {
+						return err
+					}
+
+					log.Println(result)
+					return nil
+				},
+			},
+			{
 				Name:  "register",
 				Usage: "Registers itself to the running system",
 				Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/pkg/gitgen/mod.go
+++ b/pkg/gitgen/mod.go
@@ -20,6 +20,7 @@ type PromptType int
 const (
 	PromptCommitMessage PromptType = iota
 	PromptCodeReview
+	PromptTestCase
 )
 
 var (
@@ -121,6 +122,8 @@ func getPrompt(promptType PromptType) string {
 	case PromptCodeReview:
 		prompt = "please perform a efficient and concise code review which points out crucial improvements could be changed on the target code. the target code is stated above which is an output of a git diff command. all response of this message should be wrapped in a markdown format because it will be shared in a text-only terminal interface."
 
+	case PromptTestCase:
+		prompt = "Please generate detailed test cases from the changes stated above, which is an output of a git diff command. The test cases should be comprehensive and cover all the modifications, additions, and deletions in the code. All responses to this message should be wrapped in a markdown format because it will be shared in a text-only terminal interface. Ensure that the test cases include the following details\n- Description,\n- Steps, Detailed steps to execute the test case. \n- Expected Result, The expected outcome of the test case.\n- Actual Result, (This will be filled out during testing.)"
 	}
 
 	return prompt


### PR DESCRIPTION
- Introduced a new `test` command in the main CLI application to generate test cases.
- Added flags to the `test` command for setting API key, source ref, destination ref, platform, model, and maximum tokens.
- Implemented the `PromptTestCase` in `getPrompt` to generate comprehensive test cases based on code changes.
- Updated `PromptType` with a new value, `PromptTestCase`, to handle the test case prompt generation.

This new functionality allows users to automatically generate detailed test cases from git diffs, enhancing the test coverage and aiding in software quality assurance.