### PR TITLE
feat(readme): expand docs with new platform support and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 # git-gen
 
-`git-gen` is a command-line tool developed in Go that generates commit messages and code reviews based on code changes in your project by utilizing OpenAI's ChatGPT API and Ollama API.
+`git-gen` is a command-line tool developed in Go that generates commit messages and code reviews based on code changes in your project by utilizing OpenAI's ChatGPT API, Ollama API, Anthropic's Claude API, and Google's Gemini API.
 
 ## Table of Contents
 
 - [Introduction](#introduction)
 - [Features](#features)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Commands](#commands)
+- [Supported Platforms](#supported-platforms)
+- [Configuration](#configuration)
+- [Custom Instructions](#custom-instructions)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Introduction
 
-`git-gen` is designed to assist developers in creating detailed commit messages and/or performing code reviews automatically depending on their codebase changes. By leveraging the power of ChatGPT and Ollama, `git-gen` analyzes the changes made to the code and generates meaningful output.
+`git-gen` is designed to assist developers in creating detailed commit messages and/or performing code reviews automatically depending on their codebase changes. By leveraging the power of ChatGPT, Ollama, Gemini, and Claude, `git-gen` analyzes the changes made to the code and generates meaningful output.
 
 ## Features
 
-- Generate commit messages based on code changes.
-- Performs detailed code reviews.
+- Generate commit messages based on code changes
+- Perform detailed code reviews
+- Support for multiple AI platforms (OpenAI, Ollama, Anthropic, Gemini)
+- Customizable model selection
+- Configurable token limits and timeout settings
+- Test scenario and test code generation
+- Custom instruction support via instructions.txt
+- Native Git diff implementation for accurate change detection
 
 ## Installation
 
@@ -34,76 +43,230 @@ go build ./cmd/git-gen
 ./git-gen register
 ```
 
-You can install the package should put the /usr/local/go/bin directory in your PATH environment variable.
+You can install the package by putting the /usr/local/go/bin directory in your PATH environment variable:
 
 ```sh
 go install github.com/seymahandekli/git-gen/cmd/git-gen@latest
 ```
 
-## Usage
+## Commands
 
-After building `git-gen`, you can use it from the command line. Below are some example commands to help you get started:
-
-### Using OpenAI API
-
-#### Alternative 1:
+### commit
+Generates a commit message based on your code changes.
 
 ```sh
-# Generate commit message based on your git diff command choices (default platform: openai)
-git gen commit --source "commitID" --dest "commitID" --apikey "PLATFORM_API_KEY" --platform openai --model YOUR_MODEL
-
-# default `git diff HEAD´ command
-git gen commit --apikey "PLATFORM_API_KEY"
-
-# Generate code review
-git gen review --apikey "PLATFORM_API_KEY"
-```
-
-#### Alternative 2:
-
-You don't have to specify OPENAI API KEY explicitly, you may store it to `PLATFORM_API_KEY` environment variable.
-
-```sh
-export PLATFORM_API_KEY="PLATFORM_API_KEY"
-
-# Generate commit message based on your git diff command choices (default platform: openai and default model: gpt4-o)
-git gen commit --source "commitID" --dest "commitID"
-
-# default `git diff HEAD´ command
+# Basic usage
 git gen commit
 
-# Generate code review
+# With specific source and destination
+git gen commit --source "commitID" --dest "commitID"
+
+# With platform and model
+git gen commit --platform openai --model gpt-4
+```
+
+### review
+Performs a code review of your changes.
+
+```sh
+# Basic usage
 git gen review
+
+# With specific source and destination
+git gen review --source "commitID" --dest "commitID"
+
+# With platform and model
+git gen review --platform anthropic --model claude-3-sonnet
 ```
 
-### Using Ollama API (No API Key Required)
-
-You can use the Ollama API, which does not require an API key, for free
+### test-scenarios
+Creates test scenarios based on your code changes.
 
 ```sh
-# Generate commit message based on your git diff command choices (default model: llama3)
-git gen commit --source "commitID" --dest "commitID" --platform ollama --model YOUR_MODEL
+# Basic usage
+git gen test-scenarios
 
-# default `git diff HEAD´ command
-git gen commit --platform ollama --model YOUR_MODEL
+# With specific source and destination
+git gen test-scenarios --source "commitID" --dest "commitID"
 
-# Generate code review
-git gen review --platform ollama --model YOUR_MODEL
+# With platform and model
+git gen test-scenarios --platform gemini --model gemini-pro
 ```
 
-
-For more detailed usage instructions, refer to the `--help` option:
+### test
+Creates test implementations based on your code changes.
 
 ```sh
-# General usage
-git gen --help
+# Basic usage
+git gen test
 
-# Help for commit messages feature
-git gen commit --help
+# With specific source and destination
+git gen test --source "commitID" --dest "commitID"
 
-# Help for code review feature
-git gen review --help
+# With platform and model
+git gen test --platform ollama --model llama2
 ```
+
+### register
+Registers the tool to your system for global usage.
+
+```sh
+git gen register
+```
+
+### help
+Shows help information for commands.
+
+```sh
+# Show all commands
+git gen help
+
+# Show help for specific command
+git gen help commit
+git gen help review
+git gen help test-scenarios
+git gen help test
+```
+
+## Supported Platforms
+
+`git-gen` supports multiple AI platforms, each with its own characteristics and requirements.
+
+### OpenAI
+OpenAI's models provide high-quality responses and are suitable for most use cases.
+
+```sh
+# Basic usage with OpenAI
+git gen commit --platform openai --model gpt-4
+
+# Available models:
+# - gpt-4
+# - gpt-3.5-turbo
+# - gpt-4-turbo-preview
+```
+
+**Requirements:**
+- OpenAI API key (set via `--apikey` or `PLATFORM_API_KEY` environment variable)
+- Internet connection
+- Paid API access
+
+### Ollama
+Ollama provides local model deployment, making it perfect for offline use and privacy-focused development.
+
+```sh
+# Basic usage with Ollama
+git gen commit --platform ollama --model llama2
+
+# Available models:
+# - llama2
+# - mistral
+# - codellama
+# - neural-chat
+```
+
+**Requirements:**
+- Ollama installed locally
+- No API key required
+- Sufficient local computing resources
+
+### Anthropic
+Anthropic's Claude models excel at understanding and generating code-related content.
+
+```sh
+# Basic usage with Anthropic
+git gen commit --platform anthropic --model claude-3-sonnet
+
+# Available models:
+# - claude-3-sonnet
+# - claude-3-opus
+# - claude-3-haiku
+```
+
+**Requirements:**
+- Anthropic API key (set via `--apikey` or `PLATFORM_API_KEY` environment variable)
+- Internet connection
+- Paid API access
+
+### Gemini
+Google's Gemini models provide fast and efficient responses, particularly good for code-related tasks.
+
+```sh
+# Basic usage with Gemini
+git gen commit --platform gemini --model gemini-pro
+
+# Available models:
+# - gemini-pro
+# - gemini-pro-vision
+```
+
+**Requirements:**
+- Google API key (set via `--apikey` or `PLATFORM_API_KEY` environment variable)
+- Internet connection
+- Paid API access
+
+## Configuration
+
+`git-gen` supports various configuration options that can be set through command-line flags or environment variables:
+
+### Platform Options
+- `--platform`: Choose between "openai", "ollama", "anthropic", or "gemini" (default: "openai")
+- `--model`: Specify the AI model to use (e.g., "gpt-4", "llama2", "claude-3-sonnet", "gemini-pro")
+- `--apikey`: Your platform API key (can also be set via PLATFORM_API_KEY environment variable)
+
+### Token and Timeout Settings
+- `--prompt-max-tokens`: Maximum tokens for the prompt (default: 3500)
+- `--prompt-timeout`: Request timeout in seconds (default: 3600)
+
+### Reference Settings
+- `--source`: Source reference for diff (default: "HEAD")
+- `--dest`: Destination reference for diff
+
+### Example Configuration
+
+```sh
+# Using OpenAI with custom token limit
+git gen commit --platform openai --model gpt-4 --prompt-max-tokens 4000
+
+# Using Ollama with custom timeout
+git gen commit --platform ollama --model llama2 --prompt-timeout 1800
+
+# Using Anthropic with custom source/destination
+git gen commit --platform anthropic --model claude-3-sonnet --source HEAD~2 --dest HEAD
+
+# Using Gemini with custom configuration
+git gen commit --platform gemini --model gemini-pro --prompt-max-tokens 4000
+```
+
+## Custom Instructions
+
+You can provide custom instructions for any generation task by creating an `instructions.txt` file in your project root. This file will be automatically picked up and used to customize the generation process.
+
+### Using git-gen-dotfile-generator
+
+The easiest way to create your `instructions.txt` file is to use the [git-gen-dotfile-generator](https://github.com/seymahandekli/git-gen-dotfile-generator) tool. This web-based tool provides a user-friendly interface to generate AI instructions and rules for your project.
+
+#### Features of git-gen-dotfile-generator:
+- Specify project name, role, and expertise areas
+- Define coding preferences and standards
+- Add sample code to create contextual rules
+- Download the generated instructions/rules directly
+
+#### How to use:
+1. Visit [git-gen-dotfile-generator](https://github.com/seymahandekli/git-gen-dotfile-generator)
+2. Fill out the form with your project details:
+   - Project name
+   - Role
+   - Expertise areas
+   - Coding preferences
+3. Add any sample code if needed
+4. Generate and download your `instructions.txt` file
+5. Place the file in your project root directory
+
+The `instructions.txt` file will be automatically used by `git-gen` to:
+- Generate more relevant commit messages
+- Create more accurate code reviews
+- Generate appropriate test scenarios
+- Maintain consistency with your project standards
 
 ## Contributing
 

--- a/cmd/git-gen/main.go
+++ b/cmd/git-gen/main.go
@@ -148,7 +148,7 @@ func main() {
 			},
 			{
 				Name:  "test-scenarios",
-				Usage: "CCreating test scenarios",
+				Usage: "Creating test scenarios",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:        "apikey",


### PR DESCRIPTION
- Added Anthropic's Claude and Google's Gemini APIs to supported AI platforms.
- Introduced new commands: `test-scenarios`, `test`, and `register`.
- Detailed command usage and configuration options, including platform, model, token, and timeout settings.
- Outlined platform-specific requirements and available models.
- Introduced `Custom Instructions` via `instructions.txt` for tailored output.
- Corrected typo in `main.go` command description.